### PR TITLE
ensure enough space for n-api to write a null terminator

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -290,7 +290,7 @@ impl JsString {
         let env = cx.env().to_raw();
 
         unsafe {
-            let capacity = neon_runtime::string::utf8_len(env, self.to_raw());
+            let capacity = neon_runtime::string::utf8_len(env, self.to_raw()) + 1;
             let mut buffer: Vec<u8> = Vec::with_capacity(capacity as usize);
             let p = buffer.as_mut_ptr();
             std::mem::forget(buffer);


### PR DESCRIPTION
[napi_get_value_string_utf8](https://nodejs.org/api/n-api.html#n_api_napi_get_value_string_utf8) wants to write a NULL terminator at the end, and truncates the string if it doesn't fit in the provided buffer. So we need to have an extra byte beyond the length of the string, so it can write the full thing.